### PR TITLE
Add docstrings to tests in test_logic.py

### DIFF
--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -17,6 +17,7 @@ from bq_meta_api.models import (
 @patch('bq_meta_api.logic.log.get_logger')
 @patch('bq_meta_api.logic.cache_manager')
 async def test_get_current_cache_valid_direct(mock_cache_manager, mock_get_logger):
+    """Tests get_current_cache when the cache is valid and loaded directly."""
     # Setup mocks
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
@@ -40,6 +41,7 @@ async def test_get_current_cache_valid_direct(mock_cache_manager, mock_get_logge
 @patch('bq_meta_api.logic.log.get_logger')
 @patch('bq_meta_api.logic.cache_manager')
 async def test_get_current_cache_loaded_after_none(mock_cache_manager, mock_get_logger):
+    """Tests get_current_cache when cache is initially None and reloaded."""
     # Setup mocks
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
@@ -67,6 +69,7 @@ async def test_get_current_cache_loaded_after_none(mock_cache_manager, mock_get_
 @patch('bq_meta_api.logic.log.get_logger')
 @patch('bq_meta_api.logic.cache_manager')
 async def test_get_current_cache_loaded_after_invalid(mock_cache_manager, mock_get_logger):
+    """Tests get_current_cache when existing cache is invalid and reloaded."""
     # Setup mocks
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
@@ -96,6 +99,7 @@ async def test_get_current_cache_loaded_after_invalid(mock_cache_manager, mock_g
 @patch('bq_meta_api.logic.log.get_logger')
 @patch('bq_meta_api.logic.cache_manager')
 async def test_get_current_cache_update_fails(mock_cache_manager, mock_get_logger):
+    """Tests get_current_cache when cache update fails, expecting HTTPException 503."""
     # Setup mocks
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
@@ -121,6 +125,7 @@ async def test_get_current_cache_update_fails(mock_cache_manager, mock_get_logge
 @patch('bq_meta_api.logic.log.get_logger')
 @patch('bq_meta_api.logic.get_current_cache', new_callable=AsyncMock)
 async def test_get_datasets_successful_retrieval(mock_get_current_cache, mock_get_logger):
+    """Tests get_datasets for successful retrieval of all dataset metadata."""
     # Setup mocks
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
@@ -150,6 +155,7 @@ async def test_get_datasets_successful_retrieval(mock_get_current_cache, mock_ge
 @patch('bq_meta_api.logic.log.get_logger')
 @patch('bq_meta_api.logic.get_current_cache', new_callable=AsyncMock)
 async def test_get_datasets_no_datasets_in_cache(mock_get_current_cache, mock_get_logger):
+    """Tests get_datasets when cache is empty, expecting an empty dataset list."""
     # Setup mocks
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
@@ -170,6 +176,7 @@ async def test_get_datasets_no_datasets_in_cache(mock_get_current_cache, mock_ge
 @patch('bq_meta_api.logic.log.get_logger')
 @patch('bq_meta_api.logic.get_current_cache', new_callable=AsyncMock)
 async def test_get_datasets_http_exception_propagates(mock_get_current_cache, mock_get_logger):
+    """Tests that HTTPException from get_current_cache propagates through get_datasets."""
     # Setup mocks
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
@@ -190,6 +197,7 @@ async def test_get_datasets_http_exception_propagates(mock_get_current_cache, mo
 @patch('bq_meta_api.logic.log.get_logger')
 @patch('bq_meta_api.logic.get_current_cache', new_callable=AsyncMock)
 async def test_get_datasets_generic_exception_triggers_http_exception(mock_get_current_cache, mock_get_logger):
+    """Tests that a generic exception in get_current_cache leads to HTTPException 503 in get_datasets."""
     # Setup mocks
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
@@ -213,6 +221,7 @@ async def test_get_datasets_generic_exception_triggers_http_exception(mock_get_c
 @patch('bq_meta_api.logic.log.get_logger')
 @patch('bq_meta_api.logic.get_current_cache', new_callable=AsyncMock)
 async def test_get_datasets_by_project_successful_retrieval(mock_get_current_cache, mock_get_logger):
+    """Tests get_datasets_by_project for successful retrieval for a specific project."""
     # Setup mocks
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger


### PR DESCRIPTION
This commit adds descriptive docstrings to the first nine test functions in tests/test_logic.py.

The following tests now have docstrings:
- test_get_current_cache_valid_direct
- test_get_current_cache_loaded_after_none
- test_get_current_cache_loaded_after_invalid
- test_get_current_cache_update_fails
- test_get_datasets_successful_retrieval
- test_get_datasets_no_datasets_in_cache
- test_get_datasets_http_exception_propagates
- test_get_datasets_generic_exception_triggers_http_exception
- test_get_datasets_by_project_successful_retrieval

This work is part of a larger effort to add docstrings to all tests in this file.