### PR TITLE
feat: add dataset filter configuration support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ GCP_SERVICE_ACCOUNT_KEY_PATH=
 # Required: GCPプロジェクトIDのリスト
 PROJECT_IDS=
 
+# Required: データセットフィルターのリスト（例: pj1.*,pj2.dataset1）
+DATASET_FILTERS=
+
 # --- Cache Settings ---
 # Optional: キャッシュの有効期限（秒） Defaults to 3600.
 CACHE_TTL_SECONDS=3600

--- a/bq_meta_api/core/entities.py
+++ b/bq_meta_api/core/entities.py
@@ -159,6 +159,10 @@ class Settings(BaseModel):
         ...,
         description="GCPプロジェクトIDのリスト",
     )
+    dataset_filters: List[str] = Field(
+        default_factory=list,
+        description="データセットフィルターのリスト（例: pj1.*,pj2.dataset1）",
+    )
     # キャッシュ設定
     cache_ttl_seconds: int = Field(
         3600,

--- a/bq_meta_api/repositories/cache_manager.py
+++ b/bq_meta_api/repositories/cache_manager.py
@@ -7,6 +7,7 @@ from typing import Optional, Dict, List, Tuple
 from bq_meta_api.repositories import config
 from bq_meta_api.core.entities import CachedData, DatasetMetadata, TableMetadata
 from bq_meta_api.repositories import bigquery_client, log
+from bq_meta_api.repositories.config import should_include_dataset
 
 
 # インメモリキャッシュ（シングルトン的に保持）
@@ -332,10 +333,28 @@ async def fetch_and_save_dataset(project_id: str, dataset: Dict, bq_client, time
 async def update_cache_project(
     bq_client, project_id: str, logger, timestamp
 ) -> Tuple[str, List[DatasetMetadata], Dict[str, List[TableMetadata]]]:
-    datasets = await bigquery_client.fetch_datasets(bq_client, project_id)
-    logger.info(
-        f"プロジェクト '{project_id}' から {len(datasets)} 個のデータセット情報を取得しました。"
-    )
+    all_datasets = await bigquery_client.fetch_datasets(bq_client, project_id)
+    
+    # データセットフィルターを適用
+    settings = config.get_settings()
+    if settings.dataset_filters:
+        filtered_datasets = []
+        for dataset in all_datasets:
+            if should_include_dataset(project_id, dataset.dataset_id, settings.dataset_filters):
+                filtered_datasets.append(dataset)
+                logger.debug(f"データセット {project_id}.{dataset.dataset_id} がフィルター条件に一致しました")
+            else:
+                logger.debug(f"データセット {project_id}.{dataset.dataset_id} がフィルター条件で除外されました")
+        datasets = filtered_datasets
+        logger.info(
+            f"プロジェクト '{project_id}' から {len(all_datasets)} 個のデータセットを取得し、フィルター後 {len(datasets)} 個が対象となりました。"
+        )
+    else:
+        datasets = all_datasets
+        logger.info(
+            f"プロジェクト '{project_id}' から {len(datasets)} 個のデータセット情報を取得しました。"
+        )
+    
     project_tables = {}
     tasks = [
         asyncio.create_task(

--- a/bq_meta_api/repositories/cache_manager.py
+++ b/bq_meta_api/repositories/cache_manager.py
@@ -351,9 +351,7 @@ async def update_cache_project(
         )
     else:
         datasets = all_datasets
-        logger.info(
-            f"プロジェクト '{project_id}' から {len(datasets)} 個のデータセット情報を取得しました。"
-        )
+        logger.info(f"プロジェクト '{project_id}' から {len(datasets)} 個のデータセット情報を取得しました。")
     
     project_tables = {}
     tasks = [

--- a/bq_meta_api/repositories/cache_manager.py
+++ b/bq_meta_api/repositories/cache_manager.py
@@ -334,25 +334,33 @@ async def update_cache_project(
     bq_client, project_id: str, logger, timestamp
 ) -> Tuple[str, List[DatasetMetadata], Dict[str, List[TableMetadata]]]:
     all_datasets = await bigquery_client.fetch_datasets(bq_client, project_id)
-    
+
     # データセットフィルターを適用
     settings = config.get_settings()
     if settings.dataset_filters:
         filtered_datasets = []
         for dataset in all_datasets:
-            if should_include_dataset(project_id, dataset.dataset_id, settings.dataset_filters):
+            if should_include_dataset(
+                project_id, dataset.dataset_id, settings.dataset_filters
+            ):
                 filtered_datasets.append(dataset)
-                logger.debug(f"データセット {project_id}.{dataset.dataset_id} がフィルター条件に一致しました")
+                logger.debug(
+                    f"データセット {project_id}.{dataset.dataset_id} がフィルター条件に一致しました"
+                )
             else:
-                logger.debug(f"データセット {project_id}.{dataset.dataset_id} がフィルター条件で除外されました")
+                logger.debug(
+                    f"データセット {project_id}.{dataset.dataset_id} がフィルター条件で除外されました"
+                )
         datasets = filtered_datasets
         logger.info(
             f"プロジェクト '{project_id}' から {len(all_datasets)} 個のデータセットを取得し、フィルター後 {len(datasets)} 個が対象となりました。"
         )
     else:
         datasets = all_datasets
-        logger.info(f"プロジェクト '{project_id}' から {len(datasets)} 個のデータセット情報を取得しました。")
-    
+        logger.info(
+            f"プロジェクト '{project_id}' から {len(datasets)} 個のデータセット情報を取得しました。"
+        )
+
     project_tables = {}
     tasks = [
         asyncio.create_task(

--- a/bq_meta_api/repositories/config.py
+++ b/bq_meta_api/repositories/config.py
@@ -80,27 +80,29 @@ def init_setting() -> Settings:
     return settings
 
 
-def should_include_dataset(project_id: str, dataset_id: str, filters: List[str]) -> bool:
+def should_include_dataset(
+    project_id: str, dataset_id: str, filters: List[str]
+) -> bool:
     """
     データセットがフィルター条件に一致するかどうかを判定します。
-    
+
     Args:
         project_id: プロジェクトID
         dataset_id: データセットID
         filters: フィルター条件のリスト（例: ["pj1.*", "pj2.dataset1"]）
-    
+
     Returns:
         フィルター条件に一致する場合True、一致しない場合False
         フィルターが空の場合は常にTrue（すべて含める）
     """
     if not filters:
         return True
-    
+
     full_dataset_name = f"{project_id}.{dataset_id}"
-    
+
     for filter_pattern in filters:
         # フィルターパターンをfnmatchで評価
         if fnmatch.fnmatch(full_dataset_name, filter_pattern):
             return True
-    
+
     return False

--- a/bq_meta_api/repositories/config.py
+++ b/bq_meta_api/repositories/config.py
@@ -1,7 +1,9 @@
 # config.py: Manages application configuration settings
 import os
+import fnmatch
 from dotenv import load_dotenv
 from pathlib import Path
+from typing import List
 
 from bq_meta_api.core.entities import Settings
 from bq_meta_api.repositories import log
@@ -27,6 +29,8 @@ def init_setting() -> Settings:
     # 環境変数を読み込んで初期値作成
     gcp_service_account_key_path = os.getenv("GCP_SERVICE_ACCOUNT_KEY_PATH", None)
     project_ids = os.getenv("PROJECT_IDS", "").split(",")
+    dataset_filters_str = os.getenv("DATASET_FILTERS", "")
+    dataset_filters = [f.strip() for f in dataset_filters_str.split(",") if f.strip()]
     cache_ttl_seconds = int(os.getenv("CACHE_TTL_SECONDS", 3600))
     cache_file_base_dir = os.getenv(
         "CACHE_FILE_BASE_DIR", str(root / ".bq_metadata_cache")
@@ -43,6 +47,7 @@ def init_setting() -> Settings:
     settings = Settings(
         gcp_service_account_key_path=gcp_service_account_key_path,
         project_ids=project_ids,
+        dataset_filters=dataset_filters,
         cache_ttl_seconds=cache_ttl_seconds,
         cache_file_base_dir=cache_file_base_dir,
         api_host=api_host,
@@ -73,3 +78,29 @@ def init_setting() -> Settings:
             "情報: GCP_SERVICE_ACCOUNT_KEY_PATH が設定されていません。アプリケーションはデフォルトの認証情報（ADC）を使用しようとします。"
         )
     return settings
+
+
+def should_include_dataset(project_id: str, dataset_id: str, filters: List[str]) -> bool:
+    """
+    データセットがフィルター条件に一致するかどうかを判定します。
+    
+    Args:
+        project_id: プロジェクトID
+        dataset_id: データセットID
+        filters: フィルター条件のリスト（例: ["pj1.*", "pj2.dataset1"]）
+    
+    Returns:
+        フィルター条件に一致する場合True、一致しない場合False
+        フィルターが空の場合は常にTrue（すべて含める）
+    """
+    if not filters:
+        return True
+    
+    full_dataset_name = f"{project_id}.{dataset_id}"
+    
+    for filter_pattern in filters:
+        # フィルターパターンをfnmatchで評価
+        if fnmatch.fnmatch(full_dataset_name, filter_pattern):
+            return True
+    
+    return False

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -86,7 +86,7 @@ def generate_env_example(env_vars: List[Tuple[str, Any, str]], output_path: Path
 
     # カテゴリ別にグループ化
     categories = {
-        "GCP Settings": ["GCP_SERVICE_ACCOUNT_KEY_PATH", "PROJECT_IDS"],
+        "GCP Settings": ["GCP_SERVICE_ACCOUNT_KEY_PATH", "PROJECT_IDS", "DATASET_FILTERS"],
         "Cache Settings": ["CACHE_TTL_SECONDS", "CACHE_FILE_BASE_DIR"],
         "API Server Settings": ["API_HOST", "API_PORT"],
         "Query Execution Settings": [

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -86,7 +86,11 @@ def generate_env_example(env_vars: List[Tuple[str, Any, str]], output_path: Path
 
     # カテゴリ別にグループ化
     categories = {
-        "GCP Settings": ["GCP_SERVICE_ACCOUNT_KEY_PATH", "PROJECT_IDS", "DATASET_FILTERS"],
+        "GCP Settings": [
+            "GCP_SERVICE_ACCOUNT_KEY_PATH",
+            "PROJECT_IDS",
+            "DATASET_FILTERS",
+        ],
         "Cache Settings": ["CACHE_TTL_SECONDS", "CACHE_FILE_BASE_DIR"],
         "API Server Settings": ["API_HOST", "API_PORT"],
         "Query Execution Settings": [

--- a/tests/test_dataset_filters.py
+++ b/tests/test_dataset_filters.py
@@ -1,5 +1,5 @@
 """Test dataset filtering functionality"""
-import pytest
+
 from bq_meta_api.repositories.config import should_include_dataset
 
 
@@ -14,23 +14,23 @@ class TestDatasetFiltering:
     def test_should_include_dataset_wildcard_project(self):
         """Test wildcard project filtering"""
         filters = ["pj1.*", "pj2.dataset1"]
-        
+
         # pj1.* should match any dataset in pj1
         assert should_include_dataset("pj1", "dataset1", filters) is True
         assert should_include_dataset("pj1", "dataset2", filters) is True
         assert should_include_dataset("pj1", "anydataset", filters) is True
-        
+
         # pj2.dataset1 should match only dataset1 in pj2
         assert should_include_dataset("pj2", "dataset1", filters) is True
         assert should_include_dataset("pj2", "dataset2", filters) is False
-        
+
         # pj3 should not match anything
         assert should_include_dataset("pj3", "dataset1", filters) is False
 
     def test_should_include_dataset_specific_dataset(self):
         """Test specific dataset filtering"""
         filters = ["project1.dataset1", "project2.dataset2"]
-        
+
         assert should_include_dataset("project1", "dataset1", filters) is True
         assert should_include_dataset("project1", "dataset2", filters) is False
         assert should_include_dataset("project2", "dataset1", filters) is False
@@ -40,17 +40,17 @@ class TestDatasetFiltering:
     def test_should_include_dataset_complex_patterns(self):
         """Test complex pattern matching"""
         filters = ["prod-*.*", "test-project.test_*", "analytics.daily_*"]
-        
+
         # prod-* should match any project starting with prod-
         assert should_include_dataset("prod-1", "dataset1", filters) is True
         assert should_include_dataset("prod-analytics", "users", filters) is True
         assert should_include_dataset("staging-1", "dataset1", filters) is False
-        
+
         # test-project.test_* should match datasets starting with test_ in test-project
         assert should_include_dataset("test-project", "test_users", filters) is True
         assert should_include_dataset("test-project", "test_orders", filters) is True
         assert should_include_dataset("test-project", "users", filters) is False
-        
+
         # analytics.daily_* should match datasets starting with daily_ in analytics
         assert should_include_dataset("analytics", "daily_reports", filters) is True
         assert should_include_dataset("analytics", "weekly_reports", filters) is False
@@ -58,7 +58,7 @@ class TestDatasetFiltering:
     def test_should_include_dataset_case_sensitivity(self):
         """Test case sensitivity in pattern matching"""
         filters = ["Project1.Dataset1"]
-        
+
         # Should be case sensitive
         assert should_include_dataset("Project1", "Dataset1", filters) is True
         assert should_include_dataset("project1", "dataset1", filters) is False
@@ -67,15 +67,15 @@ class TestDatasetFiltering:
     def test_should_include_dataset_example_from_issue(self):
         """Test the exact example from the GitHub issue"""
         filters = ["pj1.*", "pj2.dataset1", "pj2.dataset2"]
-        
+
         # pj1 - all datasets should be included
         assert should_include_dataset("pj1", "any_dataset", filters) is True
         assert should_include_dataset("pj1", "another_dataset", filters) is True
-        
+
         # pj2 - only dataset1 and dataset2 should be included
         assert should_include_dataset("pj2", "dataset1", filters) is True
         assert should_include_dataset("pj2", "dataset2", filters) is True
         assert should_include_dataset("pj2", "dataset3", filters) is False
-        
+
         # pj3 - nothing should be included
         assert should_include_dataset("pj3", "dataset1", filters) is False

--- a/tests/test_dataset_filters.py
+++ b/tests/test_dataset_filters.py
@@ -1,0 +1,81 @@
+"""Test dataset filtering functionality"""
+import pytest
+from bq_meta_api.repositories.config import should_include_dataset
+
+
+class TestDatasetFiltering:
+    """Test cases for dataset filtering functionality"""
+
+    def test_should_include_dataset_empty_filters(self):
+        """Test that empty filters include all datasets"""
+        assert should_include_dataset("project1", "dataset1", []) is True
+        assert should_include_dataset("project2", "dataset2", []) is True
+
+    def test_should_include_dataset_wildcard_project(self):
+        """Test wildcard project filtering"""
+        filters = ["pj1.*", "pj2.dataset1"]
+        
+        # pj1.* should match any dataset in pj1
+        assert should_include_dataset("pj1", "dataset1", filters) is True
+        assert should_include_dataset("pj1", "dataset2", filters) is True
+        assert should_include_dataset("pj1", "anydataset", filters) is True
+        
+        # pj2.dataset1 should match only dataset1 in pj2
+        assert should_include_dataset("pj2", "dataset1", filters) is True
+        assert should_include_dataset("pj2", "dataset2", filters) is False
+        
+        # pj3 should not match anything
+        assert should_include_dataset("pj3", "dataset1", filters) is False
+
+    def test_should_include_dataset_specific_dataset(self):
+        """Test specific dataset filtering"""
+        filters = ["project1.dataset1", "project2.dataset2"]
+        
+        assert should_include_dataset("project1", "dataset1", filters) is True
+        assert should_include_dataset("project1", "dataset2", filters) is False
+        assert should_include_dataset("project2", "dataset1", filters) is False
+        assert should_include_dataset("project2", "dataset2", filters) is True
+        assert should_include_dataset("project3", "dataset1", filters) is False
+
+    def test_should_include_dataset_complex_patterns(self):
+        """Test complex pattern matching"""
+        filters = ["prod-*.*", "test-project.test_*", "analytics.daily_*"]
+        
+        # prod-* should match any project starting with prod-
+        assert should_include_dataset("prod-1", "dataset1", filters) is True
+        assert should_include_dataset("prod-analytics", "users", filters) is True
+        assert should_include_dataset("staging-1", "dataset1", filters) is False
+        
+        # test-project.test_* should match datasets starting with test_ in test-project
+        assert should_include_dataset("test-project", "test_users", filters) is True
+        assert should_include_dataset("test-project", "test_orders", filters) is True
+        assert should_include_dataset("test-project", "users", filters) is False
+        
+        # analytics.daily_* should match datasets starting with daily_ in analytics
+        assert should_include_dataset("analytics", "daily_reports", filters) is True
+        assert should_include_dataset("analytics", "weekly_reports", filters) is False
+
+    def test_should_include_dataset_case_sensitivity(self):
+        """Test case sensitivity in pattern matching"""
+        filters = ["Project1.Dataset1"]
+        
+        # Should be case sensitive
+        assert should_include_dataset("Project1", "Dataset1", filters) is True
+        assert should_include_dataset("project1", "dataset1", filters) is False
+        assert should_include_dataset("PROJECT1", "DATASET1", filters) is False
+
+    def test_should_include_dataset_example_from_issue(self):
+        """Test the exact example from the GitHub issue"""
+        filters = ["pj1.*", "pj2.dataset1", "pj2.dataset2"]
+        
+        # pj1 - all datasets should be included
+        assert should_include_dataset("pj1", "any_dataset", filters) is True
+        assert should_include_dataset("pj1", "another_dataset", filters) is True
+        
+        # pj2 - only dataset1 and dataset2 should be included
+        assert should_include_dataset("pj2", "dataset1", filters) is True
+        assert should_include_dataset("pj2", "dataset2", filters) is True
+        assert should_include_dataset("pj2", "dataset3", filters) is False
+        
+        # pj3 - nothing should be included
+        assert should_include_dataset("pj3", "dataset1", filters) is False


### PR DESCRIPTION
Add DATASET_FILTERS environment variable to filter BigQuery datasets:
- Support wildcard patterns (e.g., pj1.*, pj2.dataset1) 
- Filter applied during cache updates from BigQuery
- Backward compatible - empty filters include all datasets
- Comprehensive test coverage for pattern matching logic

Resolves #13

Generated with [Claude Code](https://claude.ai/code)